### PR TITLE
refactor(logging): prevent serialization of errors

### DIFF
--- a/src/coffee/helpers/extended-logger.coffee
+++ b/src/coffee/helpers/extended-logger.coffee
@@ -14,10 +14,12 @@ module.exports = class
     @bunyanLogger = new Logger logConfig
 
   _serializeError: (e) ->
+    body: e.body
     message: e.message
     name: e.name
     stack: e.stack
     code: e.code
+    statusCode: e.statusCode
     signal: e.signal
 
   _wrapOptions: (type, opts, msg) ->


### PR DESCRIPTION
remove the serialization since it strips away all the valueable error info that the sdk added to the error object
cc/ @hajoeichler @emmenko 