### PR TITLE
Documented structure of Sphere project credential files, both JSON and non-JSON formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,21 @@ By default the module will try to read the credentials from the following locati
 * /etc/sphere-project-credentials
 * /etc/sphere-project-credentials.json
 
+The versions of these without the `.json` extension consist of a series of lines, each of which contains a project key, client ID and client secret, separated by colons:
+
+```
+project-key1:client-id1:client-secret1
+project-key2:client-id2:client-secret2
+```
+
+The JSON versions are structured as follows:
+
+```
+{
+  "project-key1": { "client_id":"client-id1", "client_secret":"client-secret1" },
+  "project-key2": { "client_id":"client-id2", "client_secret":"client-secret2" }
+}
+```
 
 Example usage:
 ```js

--- a/README.md
+++ b/README.md
@@ -216,16 +216,22 @@ By default the module will try to read the credentials from the following locati
 The versions of these without the `.json` extension consist of a series of lines, each of which contains a project key, client ID and client secret, separated by colons:
 
 ```
-project-key1:client-id1:client-secret1
-project-key2:client-id2:client-secret2
+<project-key1>:<client-id1>:<client-secret1>
+<project-key2>:<client-id2>:<client-secret2>
 ```
 
 The JSON versions are structured as follows:
 
 ```
 {
-  "project-key1": { "client_id":"client-id1", "client_secret":"client-secret1" },
-  "project-key2": { "client_id":"client-id2", "client_secret":"client-secret2" }
+  "<project-key1>": {
+    "client_id":"<client-id1>",
+    "client_secret":"<client-secret1>"
+  },
+  "<project-key2>": {
+    "client_id":"<client-id2>",
+    "client_secret":"<client-secret2>"
+  }
 }
 ```
 


### PR DESCRIPTION
Documented structure of Sphere project credential files, both JSON and non-JSON formats.

Okay, the former is reasonably obvious, but the latter, with its colon separators, was not to me; and it also took me a while to realise that the filenames without the .json extension were not expected to be expressed in JSON format at all.