### PR TITLE
Limit concurrency when downloading all files from SFTP folder

### DIFF
--- a/src/coffee/helpers/sftp.coffee
+++ b/src/coffee/helpers/sftp.coffee
@@ -245,9 +245,10 @@ class Sftp
    * @param {String} tmpFolder Local tmp folder path where to save the files to
    * @param {String} remoteFolder Remote path folder where to download the files from
    * @param {String} [fileRegex] A RegExp to be applied when filtering files
+   * @param {Number} [maxConcurrency=3] maximum number of concurrent downloads from SFTP
    * @return {Promise} A promise, fulfilled with an {Object} or rejected with an error
   ###
-  downloadAllFiles: (sftp, tmpFolder, remoteFolder, fileRegex = '') ->
+  downloadAllFiles: (sftp, tmpFolder, remoteFolder, fileRegex = '', maxConcurrency = 3) ->
     new Promise (resolve, reject) =>
       @listFiles(sftp, remoteFolder)
       .then (files) =>
@@ -259,14 +260,14 @@ class Sftp
             else regex.test(f.filename)
         Promise.map filteredFiles, ((f) =>
           @stats(sftp, "#{remoteFolder}/#{f.filename}")),
-          concurrency: 3
+          concurrency: maxConcurrency
         .then (stats) =>
           filesOnly = []
           _.each filteredFiles, (f, i) -> filesOnly.push(f) if stats[i].isFile() # here magic happens!
           debug filesOnly, "About to download"
           Promise.map filesOnly, ((f) =>
             @getFile(sftp, "#{remoteFolder}/#{f.filename}", "#{tmpFolder}/#{f.filename}")),
-            concurrency: 3
+            concurrency: maxConcurrency
         .then -> resolve()
       .catch (error) -> reject error
 


### PR DESCRIPTION
Fixes: https://github.com/sphereio/sphere-node-utils/issues/20

There were no concurrency limits when downloading all files from the folder in the SFTP. Therefore many connections were opened at once if there are many files. SFTP server probably cannot handle all of them and started to return errors and the whole process fails.

I reduce the amount of concurrency to 3 to solve this problem.