### PR TITLE
Repeater returns the whole error on the last fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "devDependencies": {
     "coffee-errors": "^0.8.6",
     "coffee-script": "^1.10.0",
+    "coffeelint": "^1.16.0",
     "coveralls": "2.11.2",
     "grunt": "0.4.5",
     "grunt-bump": "0.0.13",

--- a/src/coffee/helpers/repeater.coffee
+++ b/src/coffee/helpers/repeater.coffee
@@ -57,7 +57,9 @@ class Repeater
 
     debug '(re)-trying task, %d remaining attempts', remainingAttempts
     if remainingAttempts is 0
-      defer.reject new Error "Failed to retry the task after #{@_options.attempts} attempts. Cause: #{lastError.stack}"
+      defer.reject
+        message: "Failed to retry the task after #{@_options.attempts} attempts."
+        error: lastError
     else
       task()
       .then (r) -> defer.resolve r

--- a/src/spec/helpers/repeater.spec.coffee
+++ b/src/spec/helpers/repeater.spec.coffee
@@ -87,5 +87,9 @@ describe 'Repeater', ->
     .then -> done 'It should have failed'
     .catch (error) ->
       expect(repeated).toEqual 3
-      expect(_.startsWith(error.message, 'Failed to retry the task after 3 attempts')).toBe true
+      expected = {
+        message: 'Failed to retry the task after 3 attempts.',
+        error: new Error('foo')
+      }
+      expect(error).toEqual(expected)
       done()


### PR DESCRIPTION
When the repeater fails for the last time we need more info on the error than just the call stack.