### PR TITLE
Update dependency bunyan to 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "bluebird": "2.9.32",
-    "bunyan": "1.4.0",
+    "bunyan": "1.8.4",
     "csv": "0.3.7",
     "debug": "2.2.0",
     "q": "1.0.x",


### PR DESCRIPTION
This fixes the annoying missing DTrace errors when running npm commands in projects that have `sphere-node-utils` as a dependency.

@allcentury maybe you could try this out to confirm?