### PR TITLE
(Fix) Check error by code instead of message

### DIFF
--- a/src/coffee/helpers/sftp.coffee
+++ b/src/coffee/helpers/sftp.coffee
@@ -167,7 +167,7 @@ class Sftp
       else
         Promise.reject "The resource at #{destPath} already exist and it doesn't appear to be a file. Please check that what you want to rename is a file."
     .catch (err) =>
-      if err.message is 'No such file'
+      if err.code is 2
         debug "File #{destPath} doesn't exist, about to rename it"
         @renameFile(sftp, srcPath, destPath)
       else

--- a/src/spec/helpers/sftp.spec.coffee
+++ b/src/spec/helpers/sftp.spec.coffee
@@ -78,7 +78,7 @@ describe 'SftpHelpers', ->
         done()
       .catch (error) -> done(error)
     .catch (error) ->
-      if error.message is 'No such file'
+      if error.code is 2
         done()
       else
         done(error)


### PR DESCRIPTION
#### Description
Discovered that there are SFTP server returning different error message when `no such file` occur by providing specified path, which causes problem inside safe rename function.

#### Todo
When `no such file` occurs, check the error by code instead of message (SFTP Code =2)